### PR TITLE
Implement support for full-width pages

### DIFF
--- a/Controller/Post/View.php
+++ b/Controller/Post/View.php
@@ -75,16 +75,23 @@ class View extends \FishPig\WordPress\Controller\Action
 	    $post = $this->_getEntity();
 	    $postType = $post->getPostType();
 	    
-		if ($post->getPostType() == 'revision' && $post->getParentPost()) {
-			$postType = $post->getParentPost()->getPostType();
-		}
-	    
-	    return array_merge(
-		    parent::getLayoutHandles(),
-		    array(
-				'wordpress_' . $postType . '_view',
-				'wordpress_' . $postType . '_view_' . $post->getId(),
-		    )
-	    );
+        if ($post->getPostType() == 'revision' && $post->getParentPost()) {
+            $postType = $post->getParentPost()->getPostType();
+            $template = $post->getParentPost()->getMetaValue('_wp_page_template');
+        } else {
+            $template = $post->getMetaValue('_wp_page_template');
+        }
+
+        if (strpos($template, 'full-width') !== false) {
+            $this->getPage()->getConfig()->setPageLayout('1column');
+        }
+
+        return array_merge(
+            parent::getLayoutHandles(),
+            array(
+                'wordpress_' . $postType . '_view',
+                'wordpress_' . $postType . '_view_' . $post->getId(),
+            )
+        );
     }
 }

--- a/wptheme/template-full-width.php
+++ b/wptheme/template-full-width.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Template Name: Full Width
+ */
+
+get_template_part('index');


### PR DESCRIPTION
This adds support for selecting "Full Width" as the template in WordPress, and it will cause the page to render without the sidebar.

This behaves almost identically to how it worked in the Magento 1 FishPig.

Requires a Layout / Block / FPC cache clear when changed, but this seems the case for most changes to pages so I believe is OK.