### PR TITLE
Full page cache clear using controller

### DIFF
--- a/Block/Post.php
+++ b/Block/Post.php
@@ -8,7 +8,8 @@
 
 namespace FishPig\WordPress\Block;
 
-class Post extends \FishPig\WordPress\Block\AbstractBlock
+class Post extends \FishPig\WordPress\Block\AbstractBlock implements
+	\Magento\Framework\DataObject\IdentityInterface
 {
 	/**
 	 * Retrieve the current post object
@@ -97,5 +98,15 @@ class Post extends \FishPig\WordPress\Block\AbstractBlock
 	protected function _getBlockForPostPrepare()
 	{
 		return $this;
+	}
+
+	/**
+	 * Return identifiers for produced content
+	 *
+	 * @return array
+	 */
+	public function getIdentities()
+	{
+		return $this->getPost() ? $this->getPost()->getIdentities() : [];
 	}
 }

--- a/Controller/Post/Invalidate.php
+++ b/Controller/Post/Invalidate.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * @
+**/
+namespace FishPig\WordPress\Controller\Post;
+
+class Invalidate extends \Magento\Framework\App\Action\Action
+{
+	/**
+	 * @var \FishPig\WordPress\Model\App
+	 */
+	protected $app;
+
+	/**
+	 * @var \FishPig\WordPress\Model\App\Factory
+	 */
+	protected $factory;
+
+	/**
+	  * @var \Magento\Framework\App\CacheInterface
+	  */
+	protected $cacheManager;
+
+	/**
+	 * @var \Magento\Framework\Event\ManagerInterface
+	 */
+	protected $eventManager;
+
+	/**
+	 * Constructor
+	 *
+	 * @param \Magento\Framework\App\Action\Context $context
+	 * @param \FishPig\WordPress\Model\App $app
+	 * @param \FishPig\WordPress\Model\App\Factory $factory
+	 * @param \Magento\Framework\App\CacheInterface $cacheManager
+	 * @param \Magento\Framework\Event\ManagerInterface $eventManager
+	 */
+	public function __construct(
+		\Magento\Framework\App\Action\Context $context,
+		\FishPig\WordPress\Model\App $app,
+		\FishPig\WordPress\Model\App\Factory $factory,
+		\Magento\Framework\App\CacheInterface $cacheManager
+		)
+	{
+		$this->app = $app;
+		$this->factory = $factory;
+		$this->cacheManager = $cacheManager;
+		$this->eventManager = $context->getEventManager();
+
+		parent::__construct($context);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function execute()
+	{
+		if ($this->invalidateCache()) {
+			$result = array('result' => 'success');
+		} else {
+			$result = array('result' => 'failure');
+		}
+
+		$this->getResponse()->appendBody(json_encode($result));
+	}
+
+	/**
+	 * Attempt to invalidate cache entry
+	 */
+	protected function invalidateCache()
+	{
+		$nonce = $this->getRequest()->getParam('nonce');
+		if (!$this->verifyNonce($nonce)) {
+			return false;
+		}
+
+		$post = $this->factory->getFactory('Post')->create()->load(
+			$this->getRequest()->getParam('id')
+		);
+		if (!$post) {
+			return false;
+		}
+
+		// Clean cache related objects and then allow FPC plugins to do the same
+		$post->cleanModelCache();
+		$this->eventManager->dispatch('clean_cache_by_tags', ['object' => $post]);
+		return true;
+	}
+
+	/**
+	 * Validate given nonce
+	 */
+	protected function verifyNonce($nonce)
+	{
+		$salt = $this->app->getConfig()->getOption('fishpig_salt');
+		if (!$salt) {
+			return false;
+		}
+
+		$nonce_tick = ceil(time() / ( 86400 / 2 ));
+
+		// 0-12 hours
+		if (substr(hash_hmac('sha256', $nonce_tick . '|fishpig|invalidate', $salt), -12, 10) == $nonce) {
+			return true;
+		}
+
+		// 12-24 hours
+		if (substr(hash_hmac('sha256', ($nonce_tick - 1) . '|fishpig|invalidate', $salt), -12, 10) == $nonce) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/Model/Post.php
+++ b/Model/Post.php
@@ -771,4 +771,14 @@ class Post extends \FishPig\WordPress\Model\Meta\AbstractMeta implements Viewabl
 	 	
 	 	return $this->_getData('latest_revision');
 	 }
+
+	/**
+	 * Return cache identities
+	 *
+	 * @return string[]
+	 */
+	public function getIdentities()
+	{
+		return [self::CACHE_TAG . '_' . $this->getId()];
+	}
 }

--- a/wptheme/functions.php
+++ b/wptheme/functions.php
@@ -54,7 +54,7 @@ function fishpig_invalidate_cache( $post_id ) {
 
 	$nonce = substr( hash_hmac( 'sha256', $nonce_tick . '|fishpig|' . $action, $salt ), -12, 10 );
 
-	file_get_contents( home_url( '/wordpress/post/invalidate?id=' . $post_id . '&nonce=' . $nonce ) );
+	wp_remote_get( home_url( '/wordpress/post/invalidate?id=' . $post_id . '&nonce=' . $nonce ) );
 }
 
 add_action( 'save_post', 'fishpig_invalidate_cache' );

--- a/wptheme/functions.php
+++ b/wptheme/functions.php
@@ -50,7 +50,9 @@ function fishpig_invalidate_cache( $post_id ) {
 
 	$nonce_tick = ceil(time() / ( 86400 / 2 ));
 
-	$nonce = substr( hash_hmac( 'sha256', $nonce_tick . '|fishpig|invalidate', $salt ), -12, 10 );
+	$action = 'invalidate_' . $post_id;
+
+	$nonce = substr( hash_hmac( 'sha256', $nonce_tick . '|fishpig|' . $action, $salt ), -12, 10 );
 
 	file_get_contents( home_url( '/wordpress/post/invalidate?id=' . $post_id . '&nonce=' . $nonce ) );
 }


### PR DESCRIPTION
This is mostly a proof of concept but actually seems to work extremely well and I would welcome feedback on implementation.

On save in WordPress, it just pings a controller in Magento to clear the cache relating to a specific Post. Adding IdentityInterface to the Block and setting up the Post Model to have sane cache tag values meant all the relevant blocks and full page cache entries for a post/page ended up with the correct tags.

To stop any abuse of the endpoint it has a nonce check similar (but admittedly not as extensive/secure) to the WordPress wp_verify_nonce behaviour, using a unique salt generated on first use by WordPress.

There's likely more that could be done to improve this - such as adding cache tags for each post of a list of posts to the list block so the taxonomy pages clear when an individual post is modified, and even adding of cache tags for taxonomies themselves and additional calls to Magento to clear those.

Does this look the right direction?