### PR TITLE
Remove extraneous post load and improve layout cache identifiers for full-width posts

### DIFF
--- a/Controller/Post/View.php
+++ b/Controller/Post/View.php
@@ -72,7 +72,7 @@ class View extends \FishPig\WordPress\Controller\Action
 	**/
     public function getLayoutHandles()
     {
-	    $post = $this->_getEntity();
+	    $post = $this->getEntityObject();
 	    $postType = $post->getPostType();
 	    
         if ($post->getPostType() == 'revision' && $post->getParentPost()) {

--- a/Controller/Post/View.php
+++ b/Controller/Post/View.php
@@ -82,16 +82,20 @@ class View extends \FishPig\WordPress\Controller\Action
             $template = $post->getMetaValue('_wp_page_template');
         }
 
-        if (strpos($template, 'full-width') !== false) {
-            $this->getPage()->getConfig()->setPageLayout('1column');
-        }
+		$layoutHandles = array(
+			'wordpress_' . $postType . '_view',
+			'wordpress_' . $postType . '_view_' . $post->getId(),
+		);
 
-        return array_merge(
-            parent::getLayoutHandles(),
-            array(
-                'wordpress_' . $postType . '_view',
-                'wordpress_' . $postType . '_view_' . $post->getId(),
-            )
+		if (strpos($template, 'full-width') !== false) {
+			$this->getPage()->getConfig()->setPageLayout('1column');
+			$layoutHandles[] = 'wordpress_' . $postType . '_full-width';
+			$layoutHandles[] = 'wordpress_' . $postType . '_full-width_' . $post->getId();
+		}
+
+		return array_merge(
+			parent::getLayoutHandles(),
+			$layoutHandles
         );
     }
 }


### PR DESCRIPTION
There is a call to `_getEntity` inside the `getLayoutHandles` which causes the post to be loaded twice. However, calling `getEntityObject` ensures that the post is only loaded once and the cached copy used. So this is small performance improvement.

Additionally, this pull request adds additional layout handles to full-width posts. This ensures that when a post changes from non-full-width to full-width, only the Block/FPC cache needs to be cleaned. It does this by ensuring the cache identifier for the layout for the full width post differs from the non-full width post. Otherwise, without this, a Layout cache clear is also needed, which is unexpected, and for busy sites it's preferable to only need to clear the expected cache, in this case, the Block/FPC cache.