### PR TITLE
Initial draft of optimisation of InjectContent with paid plugins

### DIFF
--- a/Model/Plugin/AllowFishPigRouters.php
+++ b/Model/Plugin/AllowFishPigRouters.php
@@ -2,11 +2,11 @@
 /**
  *
 **/
-namespace FishPig\WordPress\Model;
+namespace FishPig\WordPress\Model\Plugin;
 
 use \Magento\Framework\App\Router\ActionList;
 
-class Plugin
+class AllowFishPigRouters
 {
 	/**
 	 * Magento 2 doesn't allow underscore in the module name
@@ -28,7 +28,7 @@ class Plugin
 		}
 
 		return str_replace('FishPig_', 'FishPig\\', $module)
-			 . '\\Controller' 
+			 . '\\Controller'
 			 . ($area ? '\\' . $area : $area)
 			 . '\\' . ucwords($namespace)
 			 . '\\' . ucwords($action);

--- a/Model/Plugin/TriggerInjectContent.php
+++ b/Model/Plugin/TriggerInjectContent.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright © 2016 FishPig. All rights reserved. http://fishpig.co.uk/magento-2/wordpress-integration/
+ */
+namespace FishPig\WordPress\Model\Plugin;
+
+/**
+ * Class TriggerInjectContent
+ */
+class TriggerInjectContent
+{
+    /**
+     * @var \Magento\Framework\Event\ManagerInterface
+     */
+    protected $eventManager;
+
+    /**
+     * @var \Magento\Framework\Registry
+     */
+    protected $registry;
+
+    /**
+     * Constructor
+     *
+     * @param \Magento\Framework\Event\ManagerInterface $eventManager
+     */
+    public function __construct(
+        \Magento\Framework\Event\ManagerInterface $eventManager,
+        \Magento\Framework\Registry $registry
+    ) {
+        $this->eventManager = $eventManager;
+        $this->registry = $registry;
+    }
+
+    /**
+     * Trigger inject content if necessary
+     * This only runs it on actual layouts, so won't run on non-block related AJAX
+     * or any API requests
+     *
+     * @param \Magento\Framework\View\Result\Layout $subject
+     * @param callable $proceed
+     * @param \Magento\Framework\App\ResponseInterface $response
+     */
+    public function aroundRenderResult(
+        \Magento\Framework\View\Result\Layout $subject,
+        callable $proceed,
+        \Magento\Framework\App\ResponseInterface $response
+    ) {
+        $result = $proceed($response);
+
+        // Did we run shortcodes that need InjectContent?
+        // If not, we don't need to inject anything so don't do anything
+        if (!$this->registry->registry('fishpig_wordpress_requires_injectcontent')) {
+            return $result;
+        }
+
+        $transport = new \Magento\Framework\DataObject([
+            'output' => $response->getBody(),
+        ]);
+
+        $this->eventManager->dispatch(
+            'fishpig_wordpress_injectcontent',
+            ['transport' => $transport]
+        );
+
+        $response->setBody($transport->getOutput());
+        return $result;
+    }
+}

--- a/Observer/InjectContent.php
+++ b/Observer/InjectContent.php
@@ -39,17 +39,11 @@ class InjectContent implements ObserverInterface
 			return $this;
 		}
 
-		if ($this->isApiRequest()) {
-			return $this;
-		}
-		
 		$content = $this->getHeadFooterContent();
 		
 		if (count($content) > 0) {
-			$bodyHtml = $observer->getEvent()
-					->getResponse()
-						->getBody();
-	
+			$bodyHtml = $observer->getEvent()->getTransport()->getOutput();
+
 			$baseUrl = $this->_app->getWpUrlBuilder()->getSiteurl();
 			$jsTemplate = '<script type="text/javascript" src="%s"></script>';
 
@@ -142,7 +136,7 @@ class InjectContent implements ObserverInterface
 			}
 			
 			// Fingers crossed and let's go!
-			$observer->getEvent()->getResponse()->setBody(str_replace('</body>', $content . '</body>', $bodyHtml));
+			$observer->getEvent()->getTransport()->setOutput(str_replace('</body>', $content . '</body>', $bodyHtml));
 		}
 		
 		return $this;
@@ -221,23 +215,7 @@ class InjectContent implements ObserverInterface
 		
 		return $externalScriptUrl;
 	}
-	
-	/**
-	 * Determine whether the request is an API request
-	 *
-	 * @return bool
-	**/
-	public function isApiRequest()
-	{
-		$pathInfo = str_replace(
-			$this->_storeManager->getStore()->getBaseUrl(), 
-			'', 
-			$this->_storeManager->getStore()->getCurrentUrl()
-		);
 
-		return strpos($pathInfo, 'api/') === 0;
-	}
-	
 	/**
 	  * @return
 	 **/

--- a/Shortcode/AbstractShortcode.php
+++ b/Shortcode/AbstractShortcode.php
@@ -227,4 +227,14 @@ abstract class AbstractShortcode
 	{
 		return '';
 	}
+
+	/**
+	 * Return true if we need to use InjectContent
+	 *
+	 * @return bool
+	 */
+	public function getRequiresInjectContent()
+	{
+		return true;
+	}
 }

--- a/Shortcode/Caption.php
+++ b/Shortcode/Caption.php
@@ -21,7 +21,16 @@ class Caption extends AbstractShortcode
 	}
 	
 	/**
+	 * Return true if we need to use InjectContent
 	 *
+	 * @return bool
+	 */
+	public function getRequiresInjectContent()
+	{
+		return false;
+	}
+
+	/**
 	 *
 	 * @return 
 	**/

--- a/Shortcode/Gallery.php
+++ b/Shortcode/Gallery.php
@@ -21,7 +21,16 @@ class Gallery extends AbstractShortcode
 	}
 	
 	/**
+	 * Return true if we need to use InjectContent
 	 *
+	 * @return bool
+	 */
+	public function getRequiresInjectContent()
+	{
+		return false;
+	}
+
+	/**
 	 *
 	 * @return 
 	**/

--- a/Shortcode/oEmbed.php
+++ b/Shortcode/oEmbed.php
@@ -35,7 +35,16 @@ class oEmbed extends AbstractShortcode
 	}
 	
 	/**
+	 * Return true if we need to use InjectContent
 	 *
+	 * @return bool
+	 */
+	public function getRequiresInjectContent()
+	{
+		return false;
+	}
+
+	/**
 	 *
 	 * @return 
 	**/

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -8,7 +8,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
 	<!-- Setup dynamic router -->
     <type name="Magento\Framework\App\Router\ActionList">
-        <plugin name="FishPig_WordPress" type="FishPig\WordPress\Model\Plugin" sortOrder="10" disabled="false"/>
+        <plugin name="FishPig_WordPress" type="FishPig\WordPress\Model\Plugin\AllowFishPigRouters" sortOrder="10" disabled="false"/>
     </type>
     <!-- Add command line actions -->
     <!--

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -17,4 +17,7 @@
 			</argument>
 		</arguments>
 	</type>
+	<type name="Magento\Framework\View\Result\Layout">
+		<plugin name="FishPig_WordPress" type="FishPig\WordPress\Model\Plugin\TriggerInjectContent" />
+	</type>
 </config>

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
-    <event name="controller_front_send_response_before">
+    <event name="fishpig_wordpress_injectcontent">
         <observer name="fishpig_wordpress" instance="FishPig\WordPress\Observer\InjectContent" />
     </event>
 </config>
-


### PR DESCRIPTION
Hi @bentideswell

I thought I'd throw up a draft of optimising the InjectContent so when using Visual Composer plugin etc it doesn't run WordPress on every page load, and definitely not on Swatches Media AJAX.

This provides following:

- Keep the Observer so the plugins keep working, but make it run from a FishPig event
- Implement new plugin over the result renderer in Magento that triggers InjectContent Observer, so that only Layout based pages consider injecting content. This means anything that returns a ResultPage or anything that renders a Layout. So API and AJAX are all excluded nicely.
- Only trigger the InjectContent if short codes were run that require it.
- AbstractShortcode by default will require the InjectContent to run when a short code is processed. The default short codes are configured to not require it. This keeps it backwards compatible with the VC / RS plugins. Of course, if don't mind breaking compatibility this could default to off, and the plugins updated to turn it on.

It has drastically sped up our home page for sure, and speeds up the swatches media AJAX too.

Thanks

Jason