### PR TITLE
Check for blogpage name before grabbing blog name

### DIFF
--- a/Model/Homepage.php
+++ b/Model/Homepage.php
@@ -34,6 +34,9 @@ class Homepage extends AbstractModel implements ViewableInterface
 	**/
 	public function getName()
 	{
+		if ($blogPage = $this->_getBlogPage()) {
+			return $blogPage->getName();
+		}
 		return $this->_viewHelper->getBlogName();
 	}
 


### PR DESCRIPTION
Implemented the same logic used for grabbing the homepage URL which checks for blog listing page first to grab the page title, and still falls back to blog name otherwise. 

I don't know if this is desired by everyone, but in our situation the blog name is slightly more specific than the overall website name, and we don't want the blog name attached to all pages in the meta info. 