### PR TITLE
Create layout handle for all WordPress templates

### DIFF
--- a/Controller/Post/View.php
+++ b/Controller/Post/View.php
@@ -115,14 +115,13 @@ class View extends \FishPig\WordPress\Controller\Action
       'wordpress_' . $postType . '_view',
       'wordpress_' . $postType . '_view_' . $post->getId(),
     );
-    
-    if (strpos($template, 'full-width') !== false) {
-      $this->getPage()->getConfig()->setPageLayout('1column');
-    
-      $layoutHandles[] = 'wordpress_' . $postType . '_view_full_width';
-      $layoutHandles[] = 'wordpress_' . $postType . '_view_full_width_' . $post->getId();
+
+    if ($template) {
+    	$templateName = str_replace('.php', '', $template);
+    	$layoutHandles[] = 'wordpress_' . $postType . '_view_' . $templateName;
+    	$layoutHandles[] = 'wordpress_' . $postType . '_view_' . $templateName . '_' . $post->getId();
     }
-    
+
     return array_merge(
       parent::getLayoutHandles(),
       $layoutHandles

--- a/view/frontend/layout/wordpress_page_view_template-full-width.xml
+++ b/view/frontend/layout/wordpress_page_view_template-full-width.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © 2016 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page layout="1column" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+
+    </body>
+</page>


### PR DESCRIPTION
This PR replaces the static "view_full_width" handle with a dynamic handle based on the current WordPress template applied to the page/post. This will allow the developers to create multiple template files in the WP theme and build out separate layouts per template. 

Currently using this feature via a Magento Plugin to this controller and it has been a great benefit for building out separate templates for the purpose of ACF field groups. This PR might be more fitting for the ACF module, but as it's encoded I'm not able to do so. 