### PR TITLE
Check for "revision" type when setting Post view template

### DIFF
--- a/Block/Post/View.php
+++ b/Block/Post/View.php
@@ -25,10 +25,11 @@ class View extends \FishPig\WordPress\Block\Post
 	protected function _beforeToHtml()
 	{
 		if (!$this->getTemplate()) {
+			$postTypeInstance = $this->getPost()->getTypeInstance();
 			$this->setTemplate('FishPig_WordPress::post/view.phtml');
-			
-			if ($this->getPost()->getPostType() !== 'post') {
-				$postTypeTemplate = 'FishPig_WordPress::' . $this->getPost()->getPostType() . '/view.phtml';
+
+			if ($postTypeInstance->getData('post_type') !== 'post') {
+				$postTypeTemplate = 'FishPig_WordPress::' . $postTypeInstance->getData('post_type') . '/view.phtml';
 
 				if ($this->getTemplateFile($postTypeTemplate)) {
 					$this->setTemplate($postTypeTemplate);

--- a/Block/Post/View.php
+++ b/Block/Post/View.php
@@ -25,11 +25,11 @@ class View extends \FishPig\WordPress\Block\Post
 	protected function _beforeToHtml()
 	{
 		if (!$this->getTemplate()) {
-			$postTypeInstance = $this->getPost()->getTypeInstance();
+			$postType = $this->getPost()->getTypeInstance();
 			$this->setTemplate('FishPig_WordPress::post/view.phtml');
 
-			if ($postTypeInstance->getData('post_type') !== 'post') {
-				$postTypeTemplate = 'FishPig_WordPress::' . $postTypeInstance->getData('post_type') . '/view.phtml';
+			if ($postType->getPostType() !== 'post') {
+				$postTypeTemplate = 'FishPig_WordPress::' . $postType->getPostType() . '/view.phtml';
 
 				if ($this->getTemplateFile($postTypeTemplate)) {
 					$this->setTemplate($postTypeTemplate);


### PR DESCRIPTION
Currently the Post View block does not account for the "revision" post type when setting the template path so the path results in `FishPig_WordPress::revision/view.phtml`. As that doesn't exist it falls back to `post/view.phtml`. However if you are viewing a Page of type Revision this does not work as expected.

This PR simply uses the already available `getTypeInstance` function on the Post model that checks for "revision" type and attempts to get the parent post type if available. This might be a very specific use case but it is one that happens at times. This solution has been temporarily implemented in one of our sites and is working as expected. 