### PR TITLE
Product post association (2.0.1.6)

### DIFF
--- a/Api/Data/PostAssociationInterface.php
+++ b/Api/Data/PostAssociationInterface.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Api\Data;
+
+use FishPig\WordPress\Api\Data\PostAssociationExtensionInterface;
+use Magento\Framework\Api\AbstractExtensibleObject;
+use Magento\Framework\Api\ExtensibleDataInterface;
+
+/**
+ * Post Association Data Interface provides a relation between Products and Blog Posts
+ *
+ * @api
+ */
+interface PostAssociationInterface extends ExtensibleDataInterface
+{
+    /**
+     * Constants for keys of data array. Identical to the name of the getter in snake case
+     */
+    const ID = 'id';
+    const PRODUCT_ID = 'product_id';
+    const POST_ID = 'post_id';
+
+    /**
+     * Get Association ID
+     *
+     * @return int|null
+     */
+    public function getId();
+
+    /**
+     * Set Association ID
+     *
+     * @param mixed $associationId
+     * @return void
+     */
+    public function setId($associationId);
+
+    /**
+     * Get Association Product ID
+     *
+     * @return int|null
+     */
+    public function getProductId();
+
+    /**
+     * Set Association Product ID
+     *
+     * @param int $productId
+     * @return void
+     */
+    public function setProductId(int $productId);
+
+    /**
+     * Get Association Post ID
+     *
+     * @return int|null
+     */
+    public function getPostId();
+
+    /**
+     * Set Association Post ID
+     *
+     * @param int $postId
+     * @return void
+     */
+    public function setPostId(int $postId);
+    
+    /**
+     * Get Extension Attirbutes
+     *
+     * @return \FishPig\WordPress\Api\Data\PostAssociationExtensionInterface|null
+     */
+    public function getExtensionAttributes();
+
+    /**
+     * Set Extension Attributes
+     *
+     * @param \FishPig\WordPress\Api\Data\PostAssociationExtensionInterface $extensionAttributes
+     * @return void
+     */
+    public function setExtensionAttributes(PostAssociationExtensionInterface $extensionAttributes);
+}

--- a/Api/Data/PostAssociationSearchResultsInterface.php
+++ b/Api/Data/PostAssociationSearchResultsInterface.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Api\Data;
+
+use Magento\Framework\Api\SearchResultsInterface;
+
+/**
+ * Search results for PostAssociationRepositoryInterface::getList method
+ *
+ * @api
+ */
+interface PostAssociationSearchResultsInterface extends SearchResultsInterface
+{
+    /**
+     * Get List of Associations
+     *
+     * @return \FishPig\WordPress\Api\Data\PostAssociationInterface[]
+     */
+    public function getItems();
+
+    /**
+     * Set List of Associations
+     *
+     * @param \FishPig\WordPress\Api\Data\PostAssociationInterface[] $items
+     * @return $this
+     */
+    public function setItems(array $items);
+}

--- a/Api/PostAssociationRepositoryInterface.php
+++ b/Api/PostAssociationRepositoryInterface.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Api;
+
+use Magento\Framework\Api\SearchCriteriaInterface;
+use FishPig\WordPress\Api\Data\PostAssociationInterface;
+use FishPig\WordPress\Api\Data\PostAssociationSearchResultsInterface;
+
+/**
+ * Post Association Repository domain manager for PostAssociationInterface
+ *
+ * @api
+ */
+interface PostAssociationRepositoryInterface
+{
+    /**
+     * Delete Post Association
+     *
+     * @param int $id
+     * @return void
+     * @throws \Magento\Framework\Exception\CouldNotDeleteException
+     */
+    public function delete(int $id);
+
+    /**
+     * Get Post Association By ID
+     *
+     * @param int $id
+     * @return \FishPig\WordPress\Api\Data\PostAssociationInterface
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function get(int $id): PostAssociationInterface;
+
+    /**
+     * Get Post Association List by optional Search Criteria
+     *
+     * @param \Magento\Framework\Api\SearchCriteriaInterface|null $searchCriteria
+     * @return \FishPig\WordPress\Api\Data\PostAssociationSearchResultsInterface
+     */
+    public function getList(SearchCriteriaInterface $searchCriteria = null): PostAssociationSearchResultsInterface;
+
+    /**
+     * Save Post Association
+     *
+     * @param \FishPig\WordPress\Api\Data\PostAssociationInterface $postAssociation
+     * @return \FishPig\WordPress\Api\Data\PostAssociationInterface
+     * @throws \Magento\Framework\Exception\CouldNotSaveException
+     */
+    public function save(PostAssociationInterface $postAssociation): PostAssociationInterface;
+
+    /**
+     * Save Multiple Post Associations
+     *
+     * @param \FishPig\WordPress\Api\Data\PostAssociationInterface[] $postAssociations
+     * @return void
+     * @throws \Magento\Framework\Exception\InputException
+     * @throws \Magento\Framework\Exception\CouldNotSaveException
+     */
+    public function saveMultiple(array $postAssociations);
+}

--- a/Block/Adminhtml/Catalog/Product/Edit/PostAssociation.php
+++ b/Block/Adminhtml/Catalog/Product/Edit/PostAssociation.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Block\Adminhtml\Catalog\Product\Edit;
+
+use FishPig\WordPress\Api\Data\PostAssociationInterface;
+use FishPig\WordPress\Api\Data\PostAssociationSearchResultsInterface;
+use FishPig\WordPress\Api\PostAssociationRepositoryInterface;
+use Magento\Backend\Block\Template;
+use Magento\Framework\Api\SearchCriteria;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Api\SearchCriteriaBuilderFactory;
+use Magento\Framework\Json\EncoderInterface;
+use Magento\Framework\Registry;
+
+class PostAssociation extends Template
+{
+    /**
+     * Block template
+     *
+     * @var string
+     */
+    protected $_template = 'catalog/product/edit/associated-posts.phtml';
+
+    /**
+     * @var Registry
+     */
+    private $coreRegistry;
+
+    /**
+     * @var \FishPig\WordPress\Block\Adminhtml\Catalog\Product\Edit\Tab\PostAssociation
+     */
+    private $blockGrid;
+
+    /**
+     * @var PostAssociationRepositoryInterface
+     */
+    private $postAssociationRepository;
+
+    /**
+     * @var SearchCriteriaBuilderFactory
+     */
+    private $searchCriteriaBuilderFactory;
+
+    /**
+     * @var EncoderInterface
+     */
+    protected $jsonEncoder;
+
+    /**
+     * PostAssociation constructor
+     * 
+     * @param Template\Context $context
+     * @param Registry $registry
+     * @param EncoderInterface $jsonEncoder
+     * @param PostAssociationRepositoryInterface $postAssociationRepository
+     * @param SearchCriteriaBuilderFactory $searchCriteriaBuilderFactory
+     * @param array $data
+     */
+    public function __construct(
+        Template\Context $context,
+        Registry $registry,
+        EncoderInterface $jsonEncoder,
+        PostAssociationRepositoryInterface $postAssociationRepository,
+        SearchCriteriaBuilderFactory $searchCriteriaBuilderFactory,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->coreRegistry = $registry;
+        $this->jsonEncoder = $jsonEncoder;
+        $this->postAssociationRepository = $postAssociationRepository;
+        $this->searchCriteriaBuilderFactory = $searchCriteriaBuilderFactory;
+    }
+
+    /**
+     * Retrieve instance of Grid Block
+     *
+     * @return Tab\PostAssociation|\Magento\Framework\View\Element\BlockInterface
+     */
+    public function getBlockGrid()
+    {
+        if (null === $this->blockGrid) {
+            $this->blockGrid = $this->getLayout()->createBlock(
+                \FishPig\WordPress\Block\Adminhtml\Catalog\Product\Edit\Tab\PostAssociation::class,
+                'product.posts.grid'
+            );
+        }
+        return $this->blockGrid;
+    }
+
+    /**
+     * Return HTML of grid block
+     *
+     * @return string
+     */
+    public function getGridHtml(): string
+    {
+        return $this->getBlockGrid()->toHtml();
+    }
+
+    /**
+     * @return string
+     */
+    public function getPostsJson(): string
+    {
+        $postIds = [];
+        /** @var ProductInterface $product */
+        $product = $this->getProduct();
+        /** @var SearchCriteriaBuilder $searchCriteriaBuilder */
+        $searchCriteriaBuilder = $this->searchCriteriaBuilderFactory->create();
+        /** @var SearchCriteria $searchCriteria */
+        $searchCriteria = $searchCriteriaBuilder->addFilter(
+            'product_id',
+            $product->getId()
+        )->create();
+        /** @var PostAssociationSearchResultsInterface $postAssociations */
+        $postAssociations = $this->postAssociationRepository->getList($searchCriteria);
+        if ($postAssociations->getTotalCount() > 0) {
+            /** @var PostAssociationInterface $postAssociation */
+            foreach ($postAssociations->getItems() as $postAssociation) {
+                $postIds[$postAssociation->getPostId()] = 1;
+            }
+        }
+        return $this->jsonEncoder->encode($postIds);
+    }
+
+    /**
+     * Retrieve current category instance
+     *
+     * @return array|null
+     */
+    public function getProduct()
+    {
+        return $this->coreRegistry->registry('product');
+    }
+}

--- a/Block/Adminhtml/Catalog/Product/Edit/Tab/PostAssociation.php
+++ b/Block/Adminhtml/Catalog/Product/Edit/Tab/PostAssociation.php
@@ -10,6 +10,8 @@ namespace FishPig\WordPress\Block\Adminhtml\Catalog\Product\Edit\Tab;
 use FishPig\WordPress\Api\Data\PostAssociationInterface;
 use FishPig\WordPress\Api\Data\PostAssociationSearchResultsInterface;
 use FishPig\WordPress\Api\PostAssociationRepositoryInterface;
+use FishPig\WordPress\Model\Post\Source\PostStatus;
+use FishPig\WordPress\Model\Post\Source\PostType;
 use FishPig\WordPress\Model\ResourceModel\Post\Collection;
 use FishPig\WordPress\Model\ResourceModel\Post\CollectionFactory;
 use Magento\Backend\Block\Widget\Grid\Extended;
@@ -44,10 +46,26 @@ class PostAssociation extends Extended
     private $searchCriteriaBuilderFactory;
 
     /**
+     * @var PostType
+     */
+    private $postTypeSource;
+
+    /**
+     * @var PostStatus
+     */
+    private $postStatusSource;
+
+    /**
      * PostAssociation constructor
      *
      * @param Context $context
      * @param Data $backendHelper
+     * @param Registry $registry
+     * @param CollectionFactory $postCollectionFactory
+     * @param PostAssociationRepositoryInterface $postAssociationRepository
+     * @param SearchCriteriaBuilderFactory $searchCriteriaBuilderFactory
+     * @param PostType $postTypeSource
+     * @param PostStatus $postStatusSource
      * @param array $data
      */
     public function __construct(
@@ -57,6 +75,8 @@ class PostAssociation extends Extended
         CollectionFactory $postCollectionFactory,
         PostAssociationRepositoryInterface $postAssociationRepository,
         SearchCriteriaBuilderFactory $searchCriteriaBuilderFactory,
+        PostType $postTypeSource,
+        PostStatus $postStatusSource,
         array $data = []
     ) {
         parent::__construct(
@@ -68,6 +88,8 @@ class PostAssociation extends Extended
         $this->postcollectionFactory = $postCollectionFactory;
         $this->postAssociationRepository = $postAssociationRepository;
         $this->searchCriteriaBuilderFactory = $searchCriteriaBuilderFactory;
+        $this->postTypeSource = $postTypeSource;
+        $this->postStatusSource = $postStatusSource;
     }
 
     /**

--- a/Block/Adminhtml/Catalog/Product/Edit/Tab/PostAssociation.php
+++ b/Block/Adminhtml/Catalog/Product/Edit/Tab/PostAssociation.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Block\Adminhtml\Catalog\Product\Edit\Tab;
+
+use FishPig\WordPress\Api\Data\PostAssociationInterface;
+use FishPig\WordPress\Api\Data\PostAssociationSearchResultsInterface;
+use FishPig\WordPress\Api\PostAssociationRepositoryInterface;
+use FishPig\WordPress\Model\ResourceModel\Post\Collection;
+use FishPig\WordPress\Model\ResourceModel\Post\CollectionFactory;
+use Magento\Backend\Block\Widget\Grid\Extended;
+use Magento\Backend\Block\Template\Context;
+use Magento\Backend\Helper\Data;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Framework\Api\SearchCriteria;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Api\SearchCriteriaBuilderFactory;
+use Magento\Framework\Registry;
+
+class PostAssociation extends Extended
+{
+    /**
+     * @var Registry
+     */
+    private $coreRegistry;
+
+    /**
+     * @var CollectionFactory
+     */
+    private $postcollectionFactory;
+
+    /**
+     * @var PostAssociationRepositoryInterface
+     */
+    private $postAssociationRepository;
+
+    /**
+     * @var SearchCriteriaBuilderFactory
+     */
+    private $searchCriteriaBuilderFactory;
+
+    /**
+     * PostAssociation constructor
+     *
+     * @param Context $context
+     * @param Data $backendHelper
+     * @param array $data
+     */
+    public function __construct(
+        Context $context,
+        Data $backendHelper,
+        Registry $registry,
+        CollectionFactory $postCollectionFactory,
+        PostAssociationRepositoryInterface $postAssociationRepository,
+        SearchCriteriaBuilderFactory $searchCriteriaBuilderFactory,
+        array $data = []
+    ) {
+        parent::__construct(
+            $context,
+            $backendHelper,
+            $data
+        );
+        $this->coreRegistry = $registry;
+        $this->postcollectionFactory = $postCollectionFactory;
+        $this->postAssociationRepository = $postAssociationRepository;
+        $this->searchCriteriaBuilderFactory = $searchCriteriaBuilderFactory;
+    }
+
+    /**
+     * Set various data properties of Grid
+     */
+    protected function _construct()
+    {
+        parent::_construct();
+        $this->setId('associatedPostsGrid');
+        $this->setDefaultSort('ID');
+        $this->setDefaultDir('DESC');
+        $this->setSaveParametersInSession(true);
+        $this->setUseAjax(true);
+    }
+
+    /**
+     * @param \Magento\Backend\Block\Widget\Grid\Column $column
+     * @return $this
+     */
+    protected function _addColumnFilterToCollection($column)
+    {
+        if ($column->getId() == 'in_posts') {
+            $postIds = $this->_getSelectedPosts();
+            if (empty($postIds)) {
+                $postIds = 0;
+            }
+            if ($column->getFilter()->getValue()) {
+                $this->getCollection()->addFieldToFilter(
+                    'ID',
+                    array(
+                        'in' => $postIds
+                    )
+                );
+            } else {
+                if ($postIds) {
+                    $this->getCollection()->addFieldToFilter(
+                        'ID',
+                        array(
+                            'nin' => $postIds
+                        )
+                    );
+                }
+            }
+        } else {
+            parent::_addColumnFilterToCollection($column);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Create/Prepare Post Collection instance
+     */
+    protected function _prepareCollection()
+    {
+        if ($this->getProduct()->getId()) {
+            $this->setDefaultFilter(['in_posts' => 1]);
+        }
+        $collection = $this->postcollectionFactory
+            ->create()
+            ->addFieldToSelect('*');
+        $this->setCollection($collection);
+        return parent::_prepareCollection();
+    }
+
+    /**
+     * Prepare Grid Columns
+     *
+     * @return $this
+     */
+    protected function _prepareColumns()
+    {
+        $this->addColumn(
+            'in_posts',
+            [
+                'header_css_class' => 'a-center',
+                'type' => 'checkbox',
+                'name' => 'in_posts',
+                'align' => 'center',
+                'index' => 'ID',
+                'values' => $this->_getSelectedPosts(),
+            ]
+        );
+
+        $this->addColumn('ID', array(
+            'header' => __('ID'),
+            'sortable' => true,
+            'width' => 60,
+            'index' => 'ID'
+        ));
+
+        $this->addColumn('post_title', array(
+            'header' => __('Post Title'),
+            'index' => 'post_title'
+        ));
+
+        $this->addColumn('post_type', array(
+            'header' => __('Post Type'),
+            'index' => 'post_type',
+            'type' => 'options',
+            'options' => $this->postTypeSource->getOptionArray()
+        ));
+
+        $this->addColumn('post_status', array(
+            'header' => __('Post Status'),
+            'index' => 'post_status',
+            'type' => 'options',
+            'options' => $this->postStatusSource->getOptionArray()
+        ));
+
+        return parent::_prepareColumns();
+    }
+
+    /**
+     * Return Grid Ajax URL
+     *
+     * @return string
+     */
+    public function getGridUrl(): string
+    {
+        return $this->getUrl(
+            'posts/product/associationGrid',
+            [
+                '_current' => true
+            ]
+        );
+    }
+
+    /**
+     * Return current Product from Registry
+     *
+     * @return mixed
+     */
+    public function getProduct()
+    {
+        return $this->coreRegistry->registry('product');
+    }
+
+    /**
+     * Return Associatied Post IDs
+     *
+     * @return array
+     */
+    protected function _getSelectedPosts(): array
+    {
+        return $this->getSelectedPosts();
+    }
+
+    /**
+     * Return Associatied Post IDs
+     *
+     * @return array
+     */
+    public function getSelectedPosts(): array
+    {
+        $postIds = $this->getRequest()->getPost('selected_posts');
+        if ($postIds === null) {
+            $postIds = [];
+            /** @var ProductInterface $product */
+            $product = $this->getProduct();
+            /** @var SearchCriteriaBuilder $searchCriteriaBuilder */
+            $searchCriteriaBuilder = $this->searchCriteriaBuilderFactory->create();
+            /** @var SearchCriteria $searchCriteria */
+            $searchCriteria = $searchCriteriaBuilder->addFilter(
+                'product_id',
+                $product->getId()
+            )->create();
+            /** @var PostAssociationSearchResultsInterface $postAssociations */
+            $postAssociations = $this->postAssociationRepository->getList($searchCriteria);
+            if ($postAssociations->getTotalCount() > 0) {
+                /** @var PostAssociationInterface $postAssociation */
+                foreach ($postAssociations->getItems() as $postAssociation) {
+                    $postIds[] = $postAssociation->getPostId();
+                }
+            }
+        }
+        return $postIds;
+    }
+}

--- a/Block/Post/Product/ListPost.php
+++ b/Block/Post/Product/ListPost.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Block\Post\Product;
+
+use FishPig\WordPress\Model\Context as WPContext;
+use FishPig\WordPress\Model\ResourceModel\Post\Collection;
+use Magento\Catalog\Api\Data\ProductExtension;
+use Magento\Framework\View\Element\Template\Context;
+
+class ListPost extends \FishPig\WordPress\Block\Post\ListPost
+{
+    /**
+     * @inheritdoc
+     */
+    public function getPosts()
+    {
+        if ($this->_postCollection === null) {
+            if ($product = $this->getProduct()) {
+                $postIds = $this->getProductsAssociatedPostIds(
+                    $product
+                );
+                if (!empty($postIds)) {
+                    $this->_postCollection = $this->factory->create(
+                        'FishPig\WordPress\Model\ResourceModel\Post\Collection'
+                    );
+                    $this->_postCollection
+                        ->addFieldToFilter('ID', ['in' => $postIds]);
+                }
+            }
+        }
+        return $this->_postCollection;
+    }
+
+    /**
+     * Return array of Blog Post IDs
+     *
+     * @param $product
+     * @return array
+     */
+    public function getProductsAssociatedPostIds($product): array
+    {
+        $postIds = [];
+        /** @var ProductExtension $extensionAttributes */
+        if ($extensionAttributes = $product->getExtensionAttributes()) {
+            $postAssociations = $extensionAttributes->getPostAssociations();
+            if (!empty($postAssociations)) {
+                $postIds = array_map(
+                    [$this, 'getPostIds'],
+                    $postAssociations
+                );
+            }
+            return $postIds;
+        }
+        return $postIds;
+    }
+
+    /**
+     * Return Post ID from Post Association
+     *
+     * @param $postAssociationItem
+     * @return int
+     */
+    private function getPostIds($postAssociationItem): int
+    {
+        return $postAssociationItem->getPostId();
+    }
+
+    /**
+     * Return Product from Registry
+     *
+     * @return mixed
+     */
+    private function getProduct()
+    {
+        return $this->wpContext->getRegistry()->registry('product');
+    }
+}

--- a/Controller/Adminhtml/Product/AssociationGrid.php
+++ b/Controller/Adminhtml/Product/AssociationGrid.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Controller\Adminhtml\Product;
+
+use FishPig\WordPress\Block\Adminhtml\Catalog\Product\Edit\Tab\PostAssociation;
+use Magento\Backend\App\Action;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\Controller\Result\Raw;
+use Magento\Framework\Controller\Result\RawFactory;
+use Magento\Framework\Registry;
+use Magento\Framework\View\LayoutFactory;
+
+class AssociationGrid extends Action
+{
+    /**
+     * Authorization level of a basic admin session
+     */
+    const ADMIN_RESOURCE = 'FishPig_WordPress::post_association';
+
+    /**
+     * @var LayoutFactory
+     */
+    private $layoutFactory;
+
+    /**
+     * @var RawFactory
+     */
+    private $resultRawFactory;
+
+    /**
+     * @var ProductRepositoryInterface
+     */
+    private $productRepository;
+
+    /**
+     * @var Registry
+     */
+    private $registry;
+
+    /**
+     * Association constructor
+     *
+     * @param Action\Context $context
+     * @param RawFactory $resultRawFactory
+     * @param LayoutFactory $layoutFactory
+     * @param ProductRepositoryInterface $productRepository
+     */
+    public function __construct(
+        Action\Context $context,
+        RawFactory $resultRawFactory,
+        LayoutFactory $layoutFactory,
+        ProductRepositoryInterface $productRepository,
+        Registry $registry
+    ) {
+        parent::__construct($context);
+        $this->resultRawFactory = $resultRawFactory;
+        $this->layoutFactory = $layoutFactory;
+        $this->productRepository = $productRepository;
+        $this->registry = $registry;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute()
+    {
+        if ($this->getRequest()->getParam('id')) {
+            $this->initProduct();
+        }
+        /** @var Raw $rawResult */
+        $rawResult = $this->resultRawFactory->create();
+        return $rawResult->setContents(
+            $this->layoutFactory->create()->createBlock(
+                PostAssociation::class,
+                'product.posts.grid'
+            )->toHtml()
+        );
+    }
+
+    /**
+     * Initialise Product and Register to Registry
+     */
+    private function initProduct()
+    {
+        $id = $this->getRequest()->getParam('id');
+        $product = $this->productRepository->getById($id);
+        if ($this->registry->registry('product') != $product) {
+            $this->registry->register('product', $product);
+        }
+    }
+}

--- a/Helper/Date.php
+++ b/Helper/Date.php
@@ -24,7 +24,7 @@ class Date extends AbstractHelper
 	public function __construct(Context $context, OptionManager $optionManager)
 	{
 		parent::__construct($context);
-		
+
 		$this->optionManager = $optionManager;
 	}
 

--- a/Helper/PostAssociation.php
+++ b/Helper/PostAssociation.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Helper;
+
+use Magento\Backend\Model\UrlInterface;
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\Helper\Context;
+
+class PostAssociation extends AbstractHelper
+{
+    /**
+     * @var UrlInterface
+     */
+    private $backendUrlBuilder;
+
+    /**
+     * Date constructor
+     *
+     * @param Context $context
+     * @param UrlInterface $backendUrlBuilder
+     */
+    public function __construct(
+        Context $context,
+        UrlInterface $backendUrlBuilder
+    ) {
+        parent::__construct($context);
+        $this->backendUrlBuilder = $backendUrlBuilder;
+    }
+
+    /**
+     * Return URL for Product Post Association Tab in Admin
+     *
+     * @return string
+     */
+    public function getProductAssociationTabUrl(): string
+    {
+        return $this->backendUrlBuilder->getUrl(
+            'posts/product/association',
+            ['current' => true]
+        );
+    }
+}

--- a/Model/Post/Source/PostStatus.php
+++ b/Model/Post/Source/PostStatus.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Model\Post\Source;
+
+use Magento\Eav\Model\Entity\Attribute\Source\AbstractSource;
+use Magento\Eav\Model\Entity\Attribute\Source\SourceInterface;
+use Magento\Framework\Data\OptionSourceInterface;
+
+class PostStatus extends AbstractSource implements SourceInterface, OptionSourceInterface
+{
+    /**#@+
+     * Blog Post Statuses
+     */
+    const AUTO_DRAFT = 'auto-draft';
+    const DRAFT = 'draft';
+    const PUBLISHED = 'publish';
+    /**#@-*/
+
+    /**
+     * @inheritdoc
+     */
+    public static function getOptionArray(): array
+    {
+        return [
+            self::AUTO_DRAFT => __('Auto Draft'),
+            self::DRAFT => __('Draft'),
+            self::PUBLISHED => __('Published')
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAllOptions(): array
+    {
+        $result = [];
+
+        foreach (self::getOptionArray() as $index => $value) {
+            $result[] = [
+                'value' => $index,
+                'label' => $value
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getOptionText($optionId)
+    {
+        $options = self::getOptionArray();
+
+        return isset($options[$optionId]) ?
+            $options[$optionId]:
+            null;
+    }
+}

--- a/Model/Post/Source/PostType.php
+++ b/Model/Post/Source/PostType.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Model\Post\Source;
+
+use Magento\Eav\Model\Entity\Attribute\Source\AbstractSource;
+use Magento\Eav\Model\Entity\Attribute\Source\SourceInterface;
+use Magento\Framework\Data\OptionSourceInterface;
+
+class PostType extends AbstractSource implements SourceInterface, OptionSourceInterface
+{
+    /**#@+
+     * Blog Post Status Contants
+     */
+    const POST = 'post';
+    const PAGE = 'page';
+    /**#@-*/
+
+    /**
+     * @inheritdoc
+     */
+    public static function getOptionArray(): array
+    {
+        return [
+            self::POST => __('Post'),
+            self::PAGE => __('Page')
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAllOptions(): array
+    {
+        $result = [];
+
+        foreach (self::getOptionArray() as $index => $value) {
+            $result[] = [
+                'value' => $index,
+                'label' => $value
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getOptionText($optionId)
+    {
+        $options = self::getOptionArray();
+
+        return isset($options[$optionId]) ?
+            $options[$optionId]:
+            null;
+    }
+}

--- a/Model/PostAssociation.php
+++ b/Model/PostAssociation.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Model;
+
+use FishPig\WordPress\Api\Data\PostAssociationExtensionInterface;
+use FishPig\WordPress\Api\Data\PostAssociationInterface;
+use FishPig\WordPress\Model\ResourceModel\PostAssociation as PostAssociationResource;
+use Magento\Framework\Model\AbstractExtensibleModel;
+
+/**
+ * @inheritdoc
+ */
+class PostAssociation extends AbstractExtensibleModel implements PostAssociationInterface
+{
+    /**
+     * @inheritdoc
+     */
+    protected function _construct()
+    {
+        $this->_init(PostAssociationResource::class);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getId()
+    {
+        return $this->getData(self::ID) === null ?
+            null:
+            (int)$this->getData(self::ID);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setId($subscriberId)
+    {
+        $this->setData(self::ID, $subscriberId);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getProductId()
+    {
+        return $this->getData(self::PRODUCT_ID) === null ?
+            null:
+            (int)$this->getData(self::PRODUCT_ID);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setProductId(int $productId)
+    {
+        $this->setData(self::PRODUCT_ID, $productId);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPostId()
+    {
+        return $this->getData(self::POST_ID) === null ?
+            null:
+            (int)$this->getData(self::POST_ID);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setPostId(int $postId)
+    {
+        $this->setData(self::POST_ID, $postId);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getExtensionAttributes(): PostAssociationExtensionInterface
+    {
+        $extensionAttributes = $this->_getExtensionAttributes();
+        if (null === $extensionAttributes) {
+            $extensionAttributes = $this->extensionAttributesFactory
+                ->create(PostAssociationInterface::class);
+            $this->setExtensionAttributes($extensionAttributes);
+        }
+        return $extensionAttributes;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setExtensionAttributes(PostAssociationExtensionInterface $extensionAttributes)
+    {
+        $this->_setExtensionAttributes($extensionAttributes);
+    }
+}

--- a/Model/PostAssociation/Command/Delete.php
+++ b/Model/PostAssociation/Command/Delete.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Model\PostAssociation\Command;
+
+use FishPig\WordPress\Api\Data\PostAssociationInterface;
+use FishPig\WordPress\Api\Data\PostAssociationInterfaceFactory;
+use FishPig\WordPress\Model\ResourceModel\PostAssociation as PostAssociationResource;
+use Magento\Framework\Exception\CouldNotDeleteException;
+
+class Delete implements DeleteInterface
+{
+    /**
+     * @var PostAssociationInterfaceFactory
+     */
+    private $postAssociationFactory;
+
+    /**
+     * @var PostAssociationResource
+     */
+    private $postAssociationResource;
+
+    /**
+     * Delete constructor
+     *
+     * @param PostAssociationInterfaceFactory $postAssociationFactory
+     * @param PostAssociationResource $postAssociationResource
+     */
+    public function __construct(
+        PostAssociationInterfaceFactory $postAssociationFactory,
+        PostAssociationResource $postAssociationResource
+    ) {
+        $this->postAssociationFactory = $postAssociationFactory;
+        $this->postAssociationResource = $postAssociationResource;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute(int $id)
+    {
+        if (null === $id) {
+            return;
+        }
+        try {
+            /** @var PostAssociationInterface $postAssociation */
+            $postAssociation = $this->postAssociationFactory->create();
+            $this->postAssociationResource->load(
+                $postAssociation,
+                $id,
+                PostAssociationInterface::ID
+            );
+            $this->postAssociationResource->delete($postAssociation);
+        } catch (\Exception $e) {
+            throw new CouldNotDeleteException(__('Could Not Delete Post Association', $e));
+        }
+    }
+}

--- a/Model/PostAssociation/Command/DeleteInterface.php
+++ b/Model/PostAssociation/Command/DeleteInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Model\PostAssociation\Command;
+
+/**
+ * Command class for Deleting Post Associations
+ *
+ * @api
+ */
+interface DeleteInterface
+{
+    /**
+     * Delete Post Association by ID
+     *
+     * @param int $id
+     * @return void
+     */
+    public function execute(int $id);
+}

--- a/Model/PostAssociation/Command/Get.php
+++ b/Model/PostAssociation/Command/Get.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Model\PostAssociation\Command;
+
+use FishPig\WordPress\Api\Data\PostAssociationInterface;
+use FishPig\WordPress\Api\Data\PostAssociationInterfaceFactory;
+use FishPig\WordPress\Model\ResourceModel\PostAssociation as PostAssociationResource;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+class Get implements GetInterface
+{
+    /**
+     * @var PostAssociationInterfaceFactory
+     */
+    private $postAssociationFactory;
+
+    /**
+     * @var PostAssociationResource
+     */
+    private $postAssociationResource;
+
+    /**
+     * Get constructor
+     *
+     * @param PostAssociationInterfaceFactory $postAssociationFactory
+     * @param PostAssociationResource $postAssociationResource
+     */
+    public function __construct(
+        PostAssociationInterfaceFactory $postAssociationFactory,
+        PostAssociationResource $postAssociationResource
+    ) {
+        $this->postAssociationFactory = $postAssociationFactory;
+        $this->postAssociationResource = $postAssociationResource;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute(int $id): PostAssociationInterface
+    {
+        /** @var PostAssociationInterface $postAssociation */
+        $postAssociation = $this->postAssociationFactory->create();
+        $this->postAssociationResource->load(
+            $postAssociation,
+            $id,
+            PostAssociationInterface::ID
+        );
+        if (null === $postAssociation->getId()) {
+            throw new NoSuchEntityException(
+                __('Post Association with ID "%id" does not exist.', ['id' => $id])
+            );
+        }
+        return $postAssociation;
+    }
+
+}

--- a/Model/PostAssociation/Command/GetInterface.php
+++ b/Model/PostAssociation/Command/GetInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Model\PostAssociation\Command;
+
+use FishPig\WordPress\Api\Data\PostAssociationInterface;
+
+/**
+ * Get Post Association by ID command (Service Provider Interface - SPI)
+ *
+ * @api
+ */
+interface GetInterface
+{
+    /**
+     * Get Post Association By ID
+     *
+     * @param int $id
+     * @return \FishPig\WordPress\Api\Data\PostAssociationInterface
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function execute(int $id): PostAssociationInterface;
+}

--- a/Model/PostAssociation/Command/GetList.php
+++ b/Model/PostAssociation/Command/GetList.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Model\PostAssociation\Command;
+
+use FishPig\WordPress\Api\Data\PostAssociationSearchResultsInterface;
+use FishPig\WordPress\Api\Data\PostAssociationSearchResultsInterfaceFactory;
+use FishPig\WordPress\Model\ResourceModel\PostAssociation\Collection;
+use FishPig\WordPress\Model\ResourceModel\PostAssociation\CollectionFactory;
+use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Api\SearchCriteriaInterface;
+
+class GetList implements GetListInterface
+{
+    /**
+     * @var PostAssociationSearchResultsInterfaceFactory
+     */
+    private $postAssociationSearchResultsFactory;
+
+    /**
+     * @var CollectionFactory
+     */
+    private $collectionFactory;
+
+    /**
+     * @var CollectionProcessorInterface
+     */
+    private $collectionProcessor;
+
+    /**
+     * @var SearchCriteriaBuilder
+     */
+    private $searchCriteriaBuilder;
+
+    /**
+     * GetList constructor
+     *
+     * @param PostAssociationSearchResultsInterfaceFactory $postAssociationSearchResultsFactory
+     * @param CollectionFactory $collectionFactory
+     * @param CollectionProcessorInterface $collectionProcessor
+     * @param SearchCriteriaBuilder $searchCriteriaBuilder
+     */
+    public function __construct(
+        PostAssociationSearchResultsInterfaceFactory $postAssociationSearchResultsFactory,
+        CollectionFactory $collectionFactory,
+        CollectionProcessorInterface $collectionProcessor,
+        SearchCriteriaBuilder $searchCriteriaBuilder
+    ) {
+        $this->postAssociationSearchResultsFactory = $postAssociationSearchResultsFactory;
+        $this->collectionFactory = $collectionFactory;
+        $this->collectionProcessor = $collectionProcessor;
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute(SearchCriteriaInterface $searchCriteria = null): PostAssociationSearchResultsInterface
+    {
+        /** @var Collection $collection */
+        $collection = $this->collectionFactory->create();
+        if (null === $searchCriteria) {
+            $searchCriteria = $this->searchCriteriaBuilder->create();
+        } else {
+            $this->collectionProcessor->process($searchCriteria, $collection);
+        }
+        /** @var PostAssociationSearchResultsInterface $searchResults */
+        $searchResults = $this->postAssociationSearchResultsFactory->create();
+        $searchResults->setItems($collection->getItems());
+        $searchResults->setTotalCount($collection->getSize());
+        $searchResults->setSearchCriteria($searchCriteria);
+        return $searchResults;
+    }
+}

--- a/Model/PostAssociation/Command/GetListInterface.php
+++ b/Model/PostAssociation/Command/GetListInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Model\PostAssociation\Command;
+
+use FishPig\WordPress\Api\Data\PostAssociationSearchResultsInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
+
+/**
+ * Get Post Association List by optional Search Criteria command (Service Provider Interface - SPI)
+ *
+ * @api
+ */
+interface GetListInterface
+{
+    /**
+     * Get Post Associations List by optional Search Criteria
+     *
+     * @param \Magento\Framework\Api\SearchCriteriaInterface|null $searchCriteria
+     * @return \FishPig\WordPress\Api\Data\PostAssociationSearchResultsInterface
+     */
+    public function execute(SearchCriteriaInterface $searchCriteria = null): PostAssociationSearchResultsInterface;
+}

--- a/Model/PostAssociation/Command/Save.php
+++ b/Model/PostAssociation/Command/Save.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Model\PostAssociation\Command;
+
+use FishPig\WordPress\Api\Data\PostAssociationInterface;
+use FishPig\WordPress\Api\Data\PostAssociationInterfaceFactory;
+use FishPig\WordPress\Model\ResourceModel\PostAssociation as PostAssociationResource;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Psr\Log\LoggerInterface;
+
+class Save implements SaveInterface
+{
+    /**
+     * @var PostAssociationInterfaceFactory
+     */
+    private $postAssociationFactory;
+
+    /**
+     * @var PostAssociationResource
+     */
+    private $postAssociationResource;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * Save constructor
+     *
+     * @param PostAssociationInterfaceFactory $postAssociationFactory
+     * @param PostAssociationResource $postAssociationResource
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        PostAssociationInterfaceFactory $postAssociationFactory,
+        PostAssociationResource $postAssociationResource,
+        LoggerInterface $logger
+    ) {
+        $this->postAssociationFactory = $postAssociationFactory;
+        $this->postAssociationResource = $postAssociationResource;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute(PostAssociationInterface $postAssociation): PostAssociationInterface
+    {
+        try {
+            if (!$postAssociation->getId()) {
+                /** @var PostAssociationInterface $existentSubscriber */
+                $existentSubscriber = $this->postAssociationFactory->create();
+                $this->postAssociationResource->load(
+                    $existentSubscriber,
+                    $postAssociation->getEmail(),
+                    PostAssociationInterface::EMAIL
+                );
+                if (null !== $existentSubscriber->getId()) {
+                    $postAssociation->setId($existentSubscriber->getId());
+                }
+            }
+            $this->postAssociationResource->save($postAssociation);
+            $postAssociation->getId();
+        } catch (\Exception $e) {
+            $this->logger->error($e->getMessage());
+            throw new CouldNotSaveException(__('Could Not Save Post Association', $e));
+        }
+        return $postAssociation;
+    }
+}

--- a/Model/PostAssociation/Command/SaveInterface.php
+++ b/Model/PostAssociation/Command/SaveInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Model\PostAssociation\Command;
+
+use FishPig\WordPress\Api\Data\PostAssociationInterface;
+
+/**
+ * Save Post Association command (Service Provider Interface - SPI)
+ *
+ * @api
+ */
+interface SaveInterface
+{
+    /**
+     * Save Post Association
+     *
+     * @param PostAssociationInterface $postAssociation
+     * @return \FishPig\WordPress\Api\Data\PostAssociationInterface
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function execute(PostAssociationInterface $postAssociation): PostAssociationInterface;
+}

--- a/Model/PostAssociation/Command/SaveMultiple.php
+++ b/Model/PostAssociation/Command/SaveMultiple.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Model\PostAssociation\Command;
+
+use FishPig\WordPress\Api\Data\PostAssociationInterface;
+use FishPig\WordPress\Model\ResourceModel\PostAssociation\SaveMultiple as SaveMultipleResource;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\InputException;
+
+/**
+ * @inheritdoc
+ */
+class SaveMultiple implements SaveMultipleInterface
+{
+    /**
+     * @var SaveMultipleResource
+     */
+    private $saveMultipleResource;
+
+    /**
+     * SaveMultiple constructor
+     *
+     * @param SaveMultipleResource $saveMultipleResource
+     */
+    public function __construct(
+        SaveMultipleResource $saveMultipleResource
+    ) {
+        $this->saveMultipleResource = $saveMultipleResource;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute(array $postAssociations)
+    {
+        if (empty($postAssociations)) {
+            throw new InputException(__('Input data is empty'));
+        }
+        try {
+            $this->saveMultipleResource->execute($postAssociations);
+        } catch (\Exception $e) {
+            var_dump($e->getMessage());die;
+            throw new CouldNotSaveException(
+                __('Could not save Post Associations',
+                    $e
+                )
+            );
+        }
+    }
+}

--- a/Model/PostAssociation/Command/SaveMultipleInterface.php
+++ b/Model/PostAssociation/Command/SaveMultipleInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Model\PostAssociation\Command;
+
+use FishPig\WordPress\Api\Data\PostAssociationInterface;
+
+/**
+ * Save Multiple Post Associations command (Service Provider Interface - SPI)
+ *
+ * @api
+ */
+interface SaveMultipleInterface
+{
+    /**
+     * Save Multiple Post Associations
+     *
+     * @param PostAssociationInterface[] $postAssociation
+     * @return void
+     * @throws \Magento\Framework\Exception\InputException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function execute(array $postAssociation);
+}

--- a/Model/PostAssociationRepository.php
+++ b/Model/PostAssociationRepository.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Model;
+
+use FishPig\WordPress\Api\Data\PostAssociationInterface;
+use FishPig\WordPress\Api\Data\PostAssociationSearchResultsInterface;
+use FishPig\WordPress\Api\PostAssociationRepositoryInterface;
+use FishPig\WordPress\Model\PostAssociation\Command\DeleteInterface;
+use FishPig\WordPress\Model\PostAssociation\Command\GetByPostIdInterface;
+use FishPig\WordPress\Model\PostAssociation\Command\GetByProductIdInterface;
+use FishPig\WordPress\Model\PostAssociation\Command\GetInterface;
+use FishPig\WordPress\Model\PostAssociation\Command\GetListInterface;
+use FishPig\WordPress\Model\PostAssociation\Command\SaveInterface;
+use FishPig\WordPress\Model\PostAssociation\Command\SaveMultipleInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
+
+/**
+ * @inheritdoc
+ */
+class PostAssociationRepository implements PostAssociationRepositoryInterface
+{
+    /**
+     * @var DeleteInterface
+     */
+    private $deleteCommand;
+
+    /**
+     * @var GetInterface
+     */
+    private $getCommand;
+
+    /**
+     * @var GetListInterface
+     */
+    private $getListCommand;
+
+    /**
+     * @var SaveInterface
+     */
+    private $saveCommand;
+
+    /**
+     * @var SaveMultipleInterface
+     */
+    private $saveMultipleCommand;
+
+    /**
+     * PostAssociationRepository constructor
+     *
+     * @param DeleteInterface $delete
+     * @param GetInterface $get
+     * @param GetListInterface $getList
+     * @param SaveInterface $save
+     * @param SaveMultipleInterface $saveMultiple
+     */
+    public function __construct(
+        DeleteInterface $delete,
+        GetInterface $get,
+        GetListInterface $getList,
+        SaveInterface $save,
+        SaveMultipleInterface $saveMultiple
+    ) {
+        $this->deleteCommand = $delete;
+        $this->getCommand = $get;
+        $this->getListCommand = $getList;
+        $this->saveCommand = $save;
+        $this->saveMultipleCommand = $saveMultiple;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function delete(int $id)
+    {
+        $this->deleteCommand->execute($id);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function get(int $id): PostAssociationInterface
+    {
+        return $this->getCommand->execute($id);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getList(SearchCriteriaInterface $searchCriteria = null): PostAssociationSearchResultsInterface
+    {
+        return $this->getListCommand->execute($searchCriteria);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function save(PostAssociationInterface $postAssociation): PostAssociationInterface
+    {
+        return $this->saveCommand->execute($postAssociation);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function saveMultiple(array $postAssociations)
+    {
+        return $this->saveMultipleCommand->execute($postAssociations);
+    }
+}

--- a/Model/PostAssociationSearchResults.php
+++ b/Model/PostAssociationSearchResults.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Model;
+
+use FishPig\WordPress\Api\Data\PostAssociationSearchResultsInterface;
+use Magento\Framework\Api\SearchResults;
+
+class PostAssociationSearchResults extends SearchResults implements PostAssociationSearchResultsInterface
+{
+}

--- a/Model/ResourceModel/PostAssociation.php
+++ b/Model/ResourceModel/PostAssociation.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Model\ResourceModel;
+
+use FishPig\WordPress\Api\Data\PostAssociationInterface;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+
+/**
+ * Post Association Resource
+ */
+class PostAssociation extends AbstractDb
+{
+    /**#@+
+     * Main Table Name Constant
+     */
+    const POST_ASSOCIATION_TABLE_NAME = 'catalog_product_post_association';
+    /**#@-*/
+
+    /**
+     * @inheritdoc
+     */
+    protected function _construct()
+    {
+        $this->_init(
+            self::POST_ASSOCIATION_TABLE_NAME,
+            PostAssociationInterface::ID
+        );
+    }
+}

--- a/Model/ResourceModel/PostAssociation/Collection.php
+++ b/Model/ResourceModel/PostAssociation/Collection.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Model\ResourceModel\PostAssociation;
+
+use FishPig\WordPress\Model\PostAssociation;
+use FishPig\WordPress\Model\ResourceModel\PostAssociation as PostAssociationResource;
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+
+/**
+ * Post Association Collection Resource
+ */
+class Collection extends AbstractCollection
+{
+    /**
+     * @inheritdoc
+     */
+    protected $_idFieldName = 'id';
+
+    /**
+     * @inheritdoc
+     */
+    public function _construct()
+    {
+        $this->_init(
+            PostAssociation::class,
+            PostAssociationResource::class
+        );
+    }
+}

--- a/Model/ResourceModel/PostAssociation/SaveMultiple.php
+++ b/Model/ResourceModel/PostAssociation/SaveMultiple.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Model\ResourceModel\PostAssociation;
+
+use Magento\Framework\App\ResourceConnection;
+use FishPig\WordPress\Model\ResourceModel\PostAssociation as PostAssociationResource;
+use FishPig\WordPress\Api\Data\PostAssociationInterface;
+
+class SaveMultiple
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * SaveMultiple constructor
+     *
+     * @param ResourceConnection $resourceConnection
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection
+    ) {
+        $this->resourceConnection = $resourceConnection;
+    }
+
+    /**
+     * Save Multiple Post Associations
+     *
+     * @param PostAssociationInterface[] $postAssociations
+     * @return void
+     */
+    public function execute(array $postAssociations)
+    {
+        if (!count($postAssociations)) {
+            return;
+        }
+        $connection = $this->resourceConnection->getConnection();
+        $tableName = $this->resourceConnection->getTableName(
+            PostAssociationResource::POST_ASSOCIATION_TABLE_NAME
+        );
+        $columnsSql = $this->buildColumnsSqlPart([
+            PostAssociationInterface::PRODUCT_ID,
+            PostAssociationInterface::POST_ID
+        ]);
+        $valuesSql = $this->buildValuesSqlPart($postAssociations);
+        $onDuplicateSql = $this->buildOnDuplicateSqlPart([
+            PostAssociationInterface::PRODUCT_ID,
+            PostAssociationInterface::POST_ID
+        ]);
+        $bind = $this->getSqlBindData($postAssociations);
+        $insertSql = sprintf(
+            'INSERT INTO %s (%s) VALUES %s %s',
+            $tableName,
+            $columnsSql,
+            $valuesSql,
+            $onDuplicateSql
+        );
+        $connection->query($insertSql, $bind);
+    }
+
+    /**
+     * @param array $columns
+     * @return string
+     */
+    private function buildColumnsSqlPart(array $columns): string
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $processedColumns = array_map([$connection, 'quoteIdentifier'], $columns);
+        $sql = implode(', ', $processedColumns);
+        return $sql;
+    }
+
+    /**
+     * @param PostAssociationInterface[] $postAssociations
+     * @return string
+     */
+    private function buildValuesSqlPart(array $postAssociations): string
+    {
+        $sql = rtrim(str_repeat('(?, ?), ', count($postAssociations)), ', ');
+        return $sql;
+    }
+
+    /**
+     * @param PostAssociationInterface[] $postAssociations
+     * @return array
+     */
+    private function getSqlBindData(array $postAssociations): array
+    {
+        $bind = [];
+        foreach ($postAssociations as $postAssociation) {
+            $bind = array_merge($bind, [
+                $postAssociation->getProductId(),
+                $postAssociation->getPostId()
+            ]);
+        }
+        return $bind;
+    }
+
+    /**
+     * @param array $fields
+     * @return string
+     */
+    private function buildOnDuplicateSqlPart(array $fields): string
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $processedFields = [];
+        foreach ($fields as $field) {
+            $processedFields[] = sprintf('%1$s = VALUES(%1$s)', $connection->quoteIdentifier($field));
+        }
+        $sql = 'ON DUPLICATE KEY UPDATE ' . implode(', ', $processedFields);
+        return $sql;
+    }
+
+}

--- a/Observer/Adminhtml/CatalogProductSave.php
+++ b/Observer/Adminhtml/CatalogProductSave.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Observer\Adminhtml;
+
+use FishPig\WordPress\Api\Data\PostAssociationInterfaceFactory;
+use FishPig\WordPress\Api\Data\PostAssociationSearchResultsInterface;
+use FishPig\WordPress\Api\PostAssociationRepositoryInterface;
+use FishPig\WordPress\Model\ResourceModel\PostAssociation\CollectionFactory;
+use Magento\Catalog\Controller\Adminhtml\Product\Save;
+use Magento\Catalog\Model\Product;
+use Magento\Framework\Api\SearchCriteria;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Api\SearchCriteriaBuilderFactory;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class CatalogProductSave implements ObserverInterface
+{
+    /**
+     * @var PostAssociationRepositoryInterface
+     */
+    private $postAssociationRepository;
+
+    /**
+     * @var PostAssociationInterfaceFactory
+     */
+    private $postAssociationFactory;
+
+    /**
+     * @var SearchCriteriaBuilderFactory
+     */
+    private $searchCriteriaBuilderFactory;
+
+    /**
+     * Array of Post IDs to associate to product
+     *
+     * @var array
+     */
+    private $postIds;
+
+    /**
+     * CatalogProductSave constructor
+     *
+     * @param PostAssociationInterfaceFactory $postAssociationFactory
+     * @param PostAssociationRepositoryInterface $postAssociationRepository
+     * @param SearchCriteriaBuilderFactory $searchCriteriaBuilderFactory
+     */
+    public function __construct(
+        PostAssociationInterfaceFactory $postAssociationFactory,
+        PostAssociationRepositoryInterface $postAssociationRepository,
+        SearchCriteriaBuilderFactory $searchCriteriaBuilderFactory
+    ) {
+        $this->postAssociationRepository = $postAssociationRepository;
+        $this->postAssociationFactory = $postAssociationFactory;
+        $this->searchCriteriaBuilderFactory = $searchCriteriaBuilderFactory;
+    }
+
+    /**
+     * Handle Admin Product Save Associated Blog Posts
+     *
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var Product $product */
+        $product = $observer->getEvent()->getProduct();
+        /** @var Save $controller */
+        $controller = $observer->getEvent()->getController();
+        $productSavePostData = $controller->getRequest()->getPostValue();
+        if (isset($productSavePostData['product_posts'])
+            && is_string($productSavePostData['product_posts'])
+        ) {
+            $posts = json_decode($productSavePostData['product_posts'], true);
+            if (!empty($posts)) {
+                $this->postIds = array_keys($posts);
+                $existentAssociatedPostIds = $this->getExistentPostIds(
+                    (int)$product->getId()
+                );
+                $postAssociationIdsToDelete = array_filter(
+                    $existentAssociatedPostIds,
+                    [$this, 'isInPostIdsToSave']
+                );
+                if (!empty($postAssociationIdsToDelete)) {
+                    $this->deletePostAssociations(array_keys($postAssociationIdsToDelete));
+                }
+                $newPostAssociations = [];
+                foreach ($this->postIds as $postId) {
+                    if (!in_array($postId, $existentAssociatedPostIds)) {
+                        $postAssociation = $this->postAssociationFactory->create();
+                        $postAssociation->setProductId((int)$product->getId());
+                        $postAssociation->setPostId((int)$postId);
+                        $newPostAssociations[] = $postAssociation;
+                    }
+                }
+                if (!empty($newPostAssociations)) {
+                    $this->postAssociationRepository->saveMultiple($newPostAssociations);
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns bool on whether post id is in ids to be saved (true if not in array)
+     *
+     * @param $postId
+     * @return bool
+     */
+    private function isInPostIdsToSave($postId): bool
+    {
+        return (!in_array($postId, $this->postIds));
+    }
+
+    /**
+     * Returns bool on whether post id is in ids to be saved (true if not in array)
+     *
+     * @param $postId
+     * @return void
+     */
+    private function deletePostAssociations($associationIdsToDelete)
+    {
+        foreach ($associationIdsToDelete as $associationIdToDelete) {
+            $this->postAssociationRepository->delete($associationIdToDelete);
+        }
+    }
+
+    /**
+     * Return array of previously associated Post Ids
+     *
+     * @param int $productId
+     * @return array
+     */
+    private function getExistentPostIds(int $productId): array
+    {
+        $associatedPostIds = [];
+        /** @var SearchCriteriaBuilder $searchCriteriaBuilder */
+        $searchCriteriaBuilder = $this->searchCriteriaBuilderFactory->create();
+        /** @var SearchCriteria $searchCriteria */
+        $searchCriteria = $searchCriteriaBuilder->addFilter(
+            'product_id',
+            $productId
+        )->create();
+        /** @var PostAssociationSearchResultsInterface $postAssociations */
+        $postAssociations = $this->postAssociationRepository->getList($searchCriteria);
+        if ($postAssociations->getTotalCount() > 0) {
+            foreach ($postAssociations->getItems() as $postAssociation) {
+                $associatedPostIds[$postAssociation->getId()] = $postAssociation->getPostId();
+            }
+        }
+        return $associatedPostIds;
+    }
+}

--- a/Plugin/Catalog/ProductRepository.php
+++ b/Plugin/Catalog/ProductRepository.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Plugin\Catalog;
+
+use FishPig\WordPress\Api\Data\PostAssociationInterface;
+use FishPig\WordPress\Api\Data\PostAssociationSearchResultsInterface;
+use FishPig\WordPress\Api\PostAssociationRepositoryInterface;
+use Magento\Catalog\Api\Data\ProductExtension;
+use Magento\Catalog\Api\Data\ProductExtensionFactory;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Api\ProductRepositoryInterface as Subject;
+use Magento\Framework\Api\SearchCriteria;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Api\SearchCriteriaBuilderFactory;
+
+class ProductRepository
+{
+    /**
+     * @var ProductExtensionFactory
+     */
+    private $extensionFactory;
+
+    /**
+     * @var PostAssociationRepositoryInterface
+     */
+    private $postAssociationRepository;
+
+    /**
+     * @var SearchCriteriaBuilderFactory
+     */
+    private $searchCriteriaBuilderFactory;
+
+    /**
+     * ProductRepository constructor
+     *
+     * @param ProductExtensionFactory $extensionFactory
+     * @param PostAssociationRepositoryInterface $postAssociationRepository
+     * @param SearchCriteriaBuilderFactory $searchCriteriaBuilderFactory
+     */
+    public function __construct(
+        ProductExtensionFactory $extensionFactory,
+        PostAssociationRepositoryInterface $postAssociationRepository,
+        SearchCriteriaBuilderFactory $searchCriteriaBuilderFactory
+    ) {
+        $this->extensionFactory = $extensionFactory;
+        $this->postAssociationRepository = $postAssociationRepository;
+        $this->searchCriteriaBuilderFactory = $searchCriteriaBuilderFactory;
+    }
+
+    /**
+     * Set Associations via ExtensionAttributes
+     *
+     * @param Subject $subject
+     * @param $sku
+     * @param $result
+     * @return mixed
+     */
+    public function afterGet(
+        Subject $subject,
+        $result,
+        $sku
+    ) {
+        /** @var ProductExtension $extensionAttributes */
+        $extensionAttributes = $result->getExtensionAttributes();
+        if (null === $extensionAttributes) {
+            $extensionAttributes = $this->extensionFactory->create();
+        }
+        if (!$extensionAttributes->getPostAssociations()) {
+            $assocations = $this->getProductPostAssociations((int)$result->getId());
+            $extensionAttributes->setPostAssociations($assocations);
+        }
+        $result->setExtensionAttributes($extensionAttributes);
+        return $result;
+    }
+
+    /**
+     * Set Associations via ExtensionAttributes
+     *
+     * @param Subject $subject
+     * @param $id
+     * @param $result
+     * @return mixed
+     */
+    public function afterGetById(
+        Subject $subject,
+        $result,
+        $id
+    ) {
+        /** @var ProductExtension $extensionAttributes */
+        $extensionAttributes = $result->getExtensionAttributes();
+        if (null === $extensionAttributes) {
+            $extensionAttributes = $this->extensionFactory->create();
+        }
+        if (!$extensionAttributes->getPostAssociations()) {
+            $assocations = $this->getProductPostAssociations((int)$result->getId());
+            $extensionAttributes->setPostAssociations($assocations);
+        }
+        $result->setExtensionAttributes($extensionAttributes);
+        return $result;
+    }
+
+    /**
+     * Set Associations via ExtensionAttributes on getList result
+     *
+     * @param Subject $subject
+     * @param $searchCriteria
+     * @param $result
+     * @return mixed
+     */
+    public function afterGetList(
+        Subject $subject,
+        $result,
+        $searchCriteria
+    ) {
+       if ($result->getTotalCount() > 0) {
+           foreach ($result->getItems() as $product) {
+               /** @var ProductExtension $extensionAttributes */
+               $extensionAttributes = $product->getExtensionAttributes();
+               if (null === $extensionAttributes) {
+                   $extensionAttributes = $this->extensionFactory->create();
+               }
+               if (!$extensionAttributes->getPostAssociations()) {
+                   $assocations = $this->getProductPostAssociations((int)$product->getId());
+                   $extensionAttributes->setPostAssociations($assocations);
+               }
+               $product->setExtensionAttributes($extensionAttributes);
+           }
+       }
+       return $result;
+    }
+
+    /**
+     * Handle saving of product assocaitions from product extension attributes passed via API
+     *
+     * @param Subject $subject
+     * @param $productToSave
+     * @param $result
+     * @return mixed
+     * @throws \Magento\Framework\Exception\CouldNotDeleteException
+     * @throws \Magento\Framework\Exception\CouldNotSaveException
+     * @throws \Magento\Framework\Exception\InputException
+     */
+    public function afterSave(
+        Subject $subject,
+        $result,
+        $productToSave
+    ) {
+        $extensionAttributes = $productToSave->getExtensionAttributes();
+        if ($extensionAttributes !== null) {
+            /** @var ProductExtension $extensionAttributes */
+            if ($postAssociations = $extensionAttributes->getPostAssociations()) {
+                $postIdsToSave = array_map(
+                    [$this, 'getIdsToSave'],
+                    $postAssociations
+                );
+                $existingPostAssociationsPostIds = $this->getProductPostAssociationsPostIds(
+                    (int)$result->getId()
+                );
+                $postAssociationsToDelete = $this->getPostAssociationsToDelete(
+                    $postIdsToSave,
+                    $existingPostAssociationsPostIds
+                );
+                if (!empty($postAssociationsToDelete)) {
+                    $this->deletePostAssociations(array_keys($postAssociationsToDelete));
+                }
+                $postAssociationsToSave = [];
+                /** @var PostAssociationInterface $postAssociation */
+                foreach ($postAssociations as $postAssociation) {
+                    if (!in_array($postAssociation->getPostId(), $existingPostAssociationsPostIds)) {
+                        $postAssociationsToSave[] = $postAssociation;
+                    }
+                }
+                if (!empty($postAssociationsToSave)) {
+                    $this->postAssociationRepository->saveMultiple($postAssociationsToSave);
+                }
+                $extensionAttributes->setPostAssociations(
+                    $this->getProductPostAssociations((int)$result->getId())
+                );
+                $result->setExtensionAttributes($extensionAttributes);
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Delete any given association post ids
+     *
+     * @param array $associatedPostIds
+     * @throws \Magento\Framework\Exception\CouldNotDeleteException
+     */
+    private function deletePostAssociations(array $associatedPostIds)
+    {
+        foreach ($associatedPostIds as $associatedPostId) {
+            $this->postAssociationRepository->delete($associatedPostId);
+        }
+    }
+
+    /**
+     * Return Post Ids to delete
+     *
+     * @param $postIdsToSave
+     * @param $existingAssociatedPostIds
+     * @return array
+     */
+    private function getPostAssociationsToDelete(
+        $postIdsToSave,
+        $existingAssociatedPostIds
+    ): array {
+        $idsToDelete = [];
+        foreach ($existingAssociatedPostIds as $assocationId => $postId) {
+            if (!in_array($postId, $postIdsToSave)) {
+                $idsToDelete[$assocationId] = $postId;
+            }
+        }
+        return $idsToDelete;
+    }
+
+    /**
+     * Return Post ID from PostAssocation Object
+     *
+     * @param PostAssociationInterface $postAssociation
+     * @return mixed
+     */
+    private function getIdsToSave($postAssociation)
+    {
+        return $postAssociation->getPostId();
+    }
+
+    /**
+     * Return Any Post Associations for given product ID
+     *
+     * @param int $productId
+     * @return array
+     */
+    public function getProductPostAssociations(int $productId): array
+    {
+        $associatedPosts = [];
+        /** @var SearchCriteriaBuilder $searchCriteriaBuilder */
+        $searchCriteriaBuilder = $this->searchCriteriaBuilderFactory->create();
+        /** @var SearchCriteria $searcCriteria */
+        $searcCriteria = $searchCriteriaBuilder->addFilter(
+            'product_id',
+            $productId
+        )->create();
+        /** @var PostAssociationSearchResultsInterface $searchResults */
+        $searchResults = $this->postAssociationRepository->getList($searcCriteria);
+        if ($searchResults->getTotalCount() > 0) {
+            $associatedPosts = $searchResults->getItems();
+        }
+        return $associatedPosts;
+    }
+
+    /**
+     * Return Any Post Associations for given product ID
+     *
+     * @param int $productId
+     * @return array
+     */
+    public function getProductPostAssociationsPostIds(int $productId): array
+    {
+        $postIds = [];
+        $associatedPosts = $this->getProductPostAssociations($productId);
+        if (!empty($associatedPosts)) {
+            foreach ($associatedPosts as $associatedPost) {
+                $postIds[$associatedPost->getId()] = $associatedPost->getPostId();
+            }
+        }
+        return $postIds;
+    }
+}

--- a/Setup/Operations/CreatePostAssociationTable.php
+++ b/Setup/Operations/CreatePostAssociationTable.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Setup\Operations;
+
+use FishPig\WordPress\Api\Data\PostAssociationInterface;
+use Magento\Framework\DB\Ddl\Table;
+use Magento\Framework\Setup\SchemaSetupInterface;
+
+/**
+ * Operational Class to create Post Association Table
+ */
+class CreatePostAssociationTable
+{
+    /**
+     * Post Association Table Name
+     */
+    const CATALOG_PRODUCT_POST_ASSOCIATION_TABLE_NAME = 'catalog_product_post_association';
+
+    /**
+     * Execute table creation logic
+     *
+     * @param SchemaSetupInterface $setup
+     */
+    public function execute(SchemaSetupInterface $setup)
+    {
+        $setup->startSetup();
+        $postAssociationTable = $setup->getConnection()->newTable(
+            $setup->getTable(
+                self::CATALOG_PRODUCT_POST_ASSOCIATION_TABLE_NAME
+            )
+        )->setComment(
+            'Product Blog Post Association Table'
+        );
+        $postAssociationTable = $this->addColumns($postAssociationTable);
+        $postAssociationTable = $this->addRelations(
+            $postAssociationTable,
+            $setup
+        );
+        $setup->getConnection()->createTable($postAssociationTable);
+        $setup->endSetup();
+    }
+
+    /**
+     * Add columns to table to match data key constants
+     * 
+     * @param Table $postAssociationTable
+     * @return Table
+     */
+    private function addColumns(Table $postAssociationTable): Table
+    {
+        return $postAssociationTable->addColumn(
+            PostAssociationInterface::ID,
+            Table::TYPE_INTEGER,
+            null,
+            [
+                'identity' => true,
+                'unsigned' => true,
+                'nullable' => false,
+                'primary' => true
+            ],
+            'Post Association Entity ID'
+        )->addColumn(
+            PostAssociationInterface::PRODUCT_ID,
+            Table::TYPE_INTEGER,
+            null,
+            [
+                'unsigned' => true,
+                'nullable' => false
+            ],
+            'Product Id'
+        )->addColumn(
+            PostAssociationInterface::POST_ID,
+            Table::TYPE_INTEGER,
+            null,
+            [
+                'unsigned' => true,
+                'nullable' => false
+            ],
+            'Post Id'
+        );
+    }
+
+    /**
+     * Add Table Relations, Foreign Keys, Indexes etc.
+     *
+     * @param Table $postAssociationTable
+     * @param SchemaSetupInterface $setup
+     * @return Table
+     */
+    private function addRelations(
+        Table $postAssociationTable,
+        SchemaSetupInterface $setup
+    ): Table {
+        return $postAssociationTable->addForeignKey(
+            $setup->getFkName(
+                self::CATALOG_PRODUCT_POST_ASSOCIATION_TABLE_NAME,
+                PostAssociationInterface::PRODUCT_ID,
+                'catalog_product_entity',
+                'entity_id'
+            ),
+            PostAssociationInterface::PRODUCT_ID,
+            $setup->getTable('catalog_product_entity'),
+            'entity_id',
+            Table::ACTION_CASCADE
+        );
+    }
+}

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @package FishPig_WordPress
+ * @author Josh Carter <josh@interjar.com>
+ */
+declare(strict_types=1);
+
+namespace FishPig\WordPress\Setup;
+
+use FishPig\WordPress\Setup\Operations\CreatePostAssociationTable;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+use Magento\Framework\Setup\UpgradeSchemaInterface;
+
+class UpgradeSchema implements UpgradeSchemaInterface
+{
+    /**
+     * @var CreatePostAssociationTable
+     */
+    private $createPostAssociationTableOperation;
+
+    /**
+     * UpgradeSchema constructor
+     *
+     * @param CreatePostAssociationTable $createPostAssociationTable
+     */
+    public function __construct(
+        CreatePostAssociationTable $createPostAssociationTable
+    ) {
+        $this->createPostAssociationTableOperation = $createPostAssociationTable;
+    }
+
+    /**
+     * Perform Module specific Schema Upgrades
+     *
+     * @param SchemaSetupInterface $setup
+     * @param ModuleContextInterface $context
+     */
+    public function upgrade(
+        SchemaSetupInterface $setup,
+        ModuleContextInterface $context
+    ) {
+        if (version_compare($context->getVersion(), '2.0.1.6') < 0) {
+            $this->createPostAssociationTableOperation->execute($setup);
+        }
+    }
+}

--- a/etc/adminhtml/acl.xml
+++ b/etc/adminhtml/acl.xml
@@ -10,6 +10,9 @@
                         </resource>
                     </resource>
                 </resource>
+                <resource id="Magento_Catalog::catalog">
+                    <resource id="FishPig_WordPress::post_association" title="Blog Post Association" translate="title" sortOrder="50" />
+                </resource>
             </resource>
         </resources>
     </acl>

--- a/etc/adminhtml/events.xml
+++ b/etc/adminhtml/events.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="controller_action_catalog_product_save_entity_after">
+        <observer name="AdminSaveProductPostAssociation" instance="FishPig\WordPress\Observer\Adminhtml\CatalogProductSave" />
+    </event>
+</config>

--- a/etc/adminhtml/routes.xml
+++ b/etc/adminhtml/routes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+    <router id="admin">
+        <route id="posts" frontName="posts">
+            <module name="FishPig_WordPress"/>
+        </route>
+    </router>
+</config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+	<!-- Post Association Interface Implementations -->
+	<preference for="FishPig\WordPress\Api\Data\PostAssociationInterface" type="FishPig\WordPress\Model\PostAssociation" />
+	<preference for="FishPig\WordPress\Api\Data\PostAssociationSearchResultsInterface" type="FishPig\WordPress\Model\PostAssociationSearchResults" />
+	<preference for="FishPig\WordPress\Api\PostAssociationRepositoryInterface" type="FishPig\WordPress\Model\PostAssociationRepository" />
+	<!-- Post Association Command Interface Implementations -->
+	<preference for="FishPig\WordPress\Model\PostAssociation\Command\DeleteInterface" type="FishPig\WordPress\Model\PostAssociation\Command\Delete" />
+	<preference for="FishPig\WordPress\Model\PostAssociation\Command\GetInterface" type="FishPig\WordPress\Model\PostAssociation\Command\Get" />
+	<preference for="FishPig\WordPress\Model\PostAssociation\Command\GetListInterface" type="FishPig\WordPress\Model\PostAssociation\Command\GetList" />
+	<preference for="FishPig\WordPress\Model\PostAssociation\Command\SaveInterface" type="FishPig\WordPress\Model\PostAssociation\Command\Save" />
+	<preference for="FishPig\WordPress\Model\PostAssociation\Command\SaveMultipleInterface" type="FishPig\WordPress\Model\PostAssociation\Command\SaveMultiple" />
+	<!-- Product Repository Plugin to Handle Extension Attribute Logic -->
+	<type name="Magento\Catalog\Api\ProductRepositoryInterface">
+		<plugin name="HandleProductAssociationExtensionAttirbuteLogic" type="FishPig\WordPress\Plugin\Catalog\ProductRepository" />
+	</type>
 	<!-- Setup dynamic router -->
 	<type name="Magento\Framework\App\Router\ActionList">
 		<plugin name="FishPig_WordPress" type="FishPig\WordPress\Plugin\Magento\Framework\App\Router\ActionListPlugin" sortOrder="10" disabled="false"/>

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
+    <extension_attributes for="Magento\Catalog\Api\Data\ProductInterface">
+        <attribute code="post_associations" type="FishPig\WordPress\Api\Data\PostAssociationInterface[]" />
+    </extension_attributes>
+</config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="FishPig_WordPress" setup_version="2.0.1.5">
+	<module name="FishPig_WordPress" setup_version="2.0.1.6">
 		<sequence>
 			<module name="Magento_Catalog"/>
 		</sequence>

--- a/view/adminhtml/templates/catalog/product/edit/associated-posts.phtml
+++ b/view/adminhtml/templates/catalog/product/edit/associated-posts.phtml
@@ -1,0 +1,22 @@
+<?php
+/** @var \FishPig\WordPress\Block\Adminhtml\Catalog\Product\Edit\PostAssociation $block */
+$blockGrid = $block->getBlockGrid();
+/** @var \FishPig\WordPress\Block\Adminhtml\Catalog\Product\Edit\Tab\PostAssociation $blockGrid */
+$gridJsObjectName = $blockGrid->getJsObjectName();
+?>
+<?= $block->getGridHtml() ?>
+<input type="hidden" name="product_posts" id="in_product_posts" data-form-part="product_form" value="" />
+<script type="text/x-magento-init">
+    {
+        "*": {
+            "FishPig_WordPress/js/catalog/product/associated-posts": {
+                "selectedPosts": <?= /* @escapeNotVerified */ $block->getPostsJson() ?>,
+                "gridJsObjectName": <?= /* @escapeNotVerified */ '"' . $gridJsObjectName . '"' ?: '{}' ?>
+            }
+        }
+    }
+</script>
+<!-- @todo remove when "UI components" will support such initialization -->
+<script>
+    require('mage/apply/main').apply();
+</script>

--- a/view/adminhtml/ui_component/product_form.xml
+++ b/view/adminhtml/ui_component/product_form.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <fieldset name="associated_posts" sortOrder="40">
+        <settings>
+            <collapsible>true</collapsible>
+            <label translate="true">Associatied Blog Posts</label>
+        </settings>
+        <container name="associated_posts_container" sortOrder="160">
+            <htmlContent name="associated_posts_content">
+                <block name="associated_posts_content_grid" class="FishPig\WordPress\Block\Adminhtml\Catalog\Product\Edit\PostAssociation"/>
+            </htmlContent>
+        </container>
+    </fieldset>
+</form>

--- a/view/adminhtml/web/js/catalog/product/associated-posts.js
+++ b/view/adminhtml/web/js/catalog/product/associated-posts.js
@@ -1,0 +1,111 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/* global $, $H */
+
+define([
+    'mage/adminhtml/grid'
+], function () {
+    'use strict';
+
+    return function (config) {
+        var selectedPosts = config.selectedPosts,
+            productPosts = $H(selectedPosts),
+            gridJsObject = window[config.gridJsObjectName],
+            tabIndex = 1000;
+
+        $('in_product_posts').value = Object.toJSON(productPosts);
+
+        /**
+         * Register Product Blog Post
+         *
+         * @param {Object} grid
+         * @param {Object} element
+         * @param {Boolean} checked
+         */
+        function registerProductPost(grid, element, checked) {
+            if (checked) {
+                if (element.positionElement) {
+                    element.positionElement.disabled = false;
+                }
+                productPosts.set(element.value, 1);
+            } else {
+                if (element.positionElement) {
+                    element.positionElement.disabled = true;
+                }
+                productPosts.unset(element.value);
+            }
+            $('in_product_posts').value = Object.toJSON(productPosts);
+            grid.reloadParams = {
+                'selected_posts[]': productPosts.keys()
+            };
+        }
+
+        /**
+         * Click on post row
+         *
+         * @param {Object} grid
+         * @param {String} event
+         */
+        function productPostRowClick(grid, event) {
+            var trElement = Event.findElement(event, 'tr'),
+                isInput = Event.element(event).tagName === 'INPUT',
+                checked = false,
+                checkbox = null;
+
+            if (trElement) {
+                checkbox = Element.getElementsBySelector(trElement, 'input');
+                console.log(checkbox);
+                if (checkbox[0]) {
+                    checked = isInput ? checkbox[0].checked : !checkbox[0].checked;
+                    gridJsObject.setCheckboxChecked(checkbox[0], checked);
+                }
+            }
+        }
+
+        /**
+         * Change post position
+         *
+         * @param {String} event
+         */
+        function positionChange(event) {
+            var element = Event.element(event);
+
+            if (element && element.checkboxElement && element.checkboxElement.checked) {
+                productPosts.set(element.checkboxElement.value, element.value);
+                $('in_product_posts').value = Object.toJSON(productPosts);
+            }
+        }
+
+        /**
+         * Initialize Product Post row
+         *
+         * @param {Object} grid
+         * @param {String} row
+         */
+        function productPostRowInit(grid, row) {
+            var checkbox = $(row).getElementsByClassName('checkbox')[0],
+                position = $(row).getElementsByClassName('input-text')[0];
+
+            if (checkbox && position) {
+                checkbox.positionElement = position;
+                position.checkboxElement = checkbox;
+                position.disabled = !checkbox.checked;
+                position.tabIndex = tabIndex++;
+                Event.observe(position, 'keyup', positionChange);
+            }
+        }
+
+        gridJsObject.rowClickCallback = productPostRowClick;
+        gridJsObject.initRowCallback = productPostRowInit;
+        gridJsObject.checkboxCheckCallback = registerProductPost;
+
+        if (gridJsObject.rows) {
+            gridJsObject.rows.each(function (row) {
+                productPostRowInit(gridJsObject, row);
+            });
+        }
+    };
+});

--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content.aside">
+            <block class="FishPig\WordPress\Block\Post\Product\ListPost" name="wp.post.list" template="post/list.phtml" />
+        </referenceContainer>
+    </body>
+</page>


### PR DESCRIPTION
Ref issue https://github.com/bentideswell/magento2-wordpress-integration/issues/43

I've implemented the required components for Product <=> Post association, they are:

- New Table for new data `catalog_product_post_association`
- New Data Object PostAssociation /w Interfaces, implementations, Collection, Resource etc.
- Plugins on ProductRepository operations to handle extension attribute getting/setting
- Adminhtml Implementation of Associated Blog Posts Grid similar to M1
- Frontend Block implementation for displaying Associated Posts on Product view