### PR TITLE
New method to allow ordering by menu order field

### DIFF
--- a/Model/ResourceModel/Post/Collection.php
+++ b/Model/ResourceModel/Post/Collection.php
@@ -538,4 +538,15 @@ class Collection extends AbstractMetaCollection
 
 		return intval($this->_totalRecords);
 	}
+	
+	/**
+	* Order the collection by the menu order field
+	*
+	* @param string $dir
+	* @return
+	*/
+	public function setOrderByMenuOrder($dir = 'asc')
+	{
+		return $this->getSelect()->order('menu_order ' . $dir);
+	}
 }


### PR DESCRIPTION
New method to allow ordering by the menu order field, useful when using reordering plugins