### PR TITLE
New method for ordering posts by menu order field

### DIFF
--- a/Model/ResourceModel/Post/Collection.php
+++ b/Model/ResourceModel/Post/Collection.php
@@ -538,4 +538,17 @@ class Collection extends AbstractMetaCollection
 
 		return intval($this->_totalRecords);
 	}
+	
+	/**
+	* Order the collection by the menu order field
+	*
+	* @param string $dir
+	* @return
+	*/
+	public function setOrderByMenuOrder($dir = 'asc')
+	{
+		$this->getSelect()->order('menu_order ' . $dir);
+
+		return $this;
+	}
 }


### PR DESCRIPTION
New method that allows the ordering of posts by the menu order field, useful when using reorder plugins.