### PR TITLE
Fix error when redirect uses uppercase Location header.

### DIFF
--- a/App/HTTP/RequestManager.php
+++ b/App/HTTP/RequestManager.php
@@ -226,7 +226,7 @@ class RequestManager
                     $msg = __(
                         "Invalid HTTP status code %1 (redirect). Redirect URL was %2.",
                         $client->getStatus(),
-                        $headers['location']
+                        $location
                     );
                 }
             }


### PR DESCRIPTION
I ran into the error `Notice: Undefined index: location in /vendor/fishpig/magento2-wordpress-integration/App/HTTP/RequestManager.php on line 229` when the redirect used an uppercase location header. 