### PR TITLE
Update BuildThemePackageCommand.php

### DIFF
--- a/Console/Command/BuildThemePackageCommand.php
+++ b/Console/Command/BuildThemePackageCommand.php
@@ -104,7 +104,7 @@ class BuildThemePackageCommand extends \Symfony\Component\Console\Command\Comman
     /**
      *
      */
-    public function getAliases()
+    public function getAliases(): array
     {
         return [
             'fishpig:wordpress:build-theme'


### PR DESCRIPTION
Hi,

We're trying to update to Magento.2.4.7-beta3 and experience this issue:

```
❯ bin/magento                                                                                                                                                                                                                     ─╯
PHP Fatal error:  Declaration of FishPig\WordPress\Console\Command\BuildThemePackageCommand::getAliases() must be compatible with Symfony\Component\Console\Command\Command::getAliases(): array in /var/www/html/vendor/fishpig/magento2-wordpress-integration/Console/Command/BuildThemePackageCommand.php on line 107
```

Adding a type to the function fixes this.

Symfony/Console is using 6.4.2 as package number in Magento 2.4.7-beta3.